### PR TITLE
Fix MapView cleanup bug

### DIFF
--- a/travel-time-app/src/MapView.jsx
+++ b/travel-time-app/src/MapView.jsx
@@ -38,8 +38,10 @@ export default function MapView({ origin, destinations }) {
         const d = await geocode(dest.address, apiKey);
         if (d) all.push({ ...d, label: dest.label, address: dest.address });
       }
-      if (isMounted) setMarkers(all);
-      setLoading(false);
+      if (isMounted) {
+        setMarkers(all);
+        setLoading(false);
+      }
     }
     if (apiKey) fetchCoords();
     return () => { isMounted = false; };


### PR DESCRIPTION
## Summary
- avoid updating loading state on an unmounted MapView

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686765b7622c83209066c71174496476