### PR TITLE
Add jest tests for travel-time API

### DIFF
--- a/travel-time-app/package.json
+++ b/travel-time-app/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start:server": "node server/index.js"
+    "start:server": "node server/index.js",
+    "test": "jest"
   },
   "dependencies": {
     "@react-google-maps/api": "^2.20.6",
@@ -21,6 +22,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/travel-time-app/server/index.js
+++ b/travel-time-app/server/index.js
@@ -76,6 +76,10 @@ app.post('/api/travel-times', async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`Backend listening on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Backend listening on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/travel-time-app/server/index.test.js
+++ b/travel-time-app/server/index.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+const axios = require('axios');
+const app = require('./index');
+
+describe('POST /api/travel-times', () => {
+  beforeEach(() => {
+    process.env.MAPS_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns results array for valid input', async () => {
+    const mockData = {
+      status: 'OK',
+      rows: [{
+        elements: [{
+          status: 'OK',
+          duration: { text: '1 min' },
+          distance: { text: '1 km' }
+        }]
+      }]
+    };
+    jest.spyOn(axios, 'get').mockResolvedValue({ data: mockData });
+
+    const res = await request(app)
+      .post('/api/travel-times')
+      .send({ origin: 'A', destinations: ['B'] });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('results');
+    expect(Array.isArray(res.body.results)).toBe(true);
+  });
+
+  it('returns 400 for missing parameters', async () => {
+    const res = await request(app)
+      .post('/api/travel-times')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- support testing by exporting the Express app from `server/index.js`
- add jest & supertest as dev dependencies
- add `/server/index.test.js` with basic API tests
- expose a `test` script in package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686768d1ce5c832092fd9c116736d041